### PR TITLE
Use quad diff for processing

### DIFF
--- a/lib/helpers.d.ts
+++ b/lib/helpers.d.ts
@@ -1,4 +1,4 @@
 import { Quad } from 'feedbackfruits-knowledge-engine';
-export declare function getDoc(subject: any): Promise<Quad[]>;
+export declare function getQuads(subject: any): Promise<Quad[]>;
 export declare function writeQuads(quads: Quad[]): any;
 export declare function deleteQuads(quads: Quad[]): any;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -11,7 +11,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const feedbackfruits_knowledge_engine_1 = require("feedbackfruits-knowledge-engine");
 const node_fetch_1 = require("node-fetch");
 const config_1 = require("./config");
-function getDoc(subject) {
+function getQuads(subject) {
     return __awaiter(this, void 0, void 0, function* () {
         console.log('Getting doc:', subject);
         const query = `
@@ -41,11 +41,11 @@ function getDoc(subject) {
         })
             .then(({ result }) => {
             console.log('Returning resulting quads:', result);
-            return result;
+            return (result || []);
         });
     });
 }
-exports.getDoc = getDoc;
+exports.getQuads = getQuads;
 function writeQuads(quads) {
     const nquads = feedbackfruits_knowledge_engine_1.Helpers.quadsToNQuads(quads);
     console.log('Writing p-quads:', nquads);

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,49 +12,38 @@ const memux_1 = require("memux");
 const feedbackfruits_knowledge_engine_1 = require("feedbackfruits-knowledge-engine");
 const Cayley = require('cayley');
 const jsonld = require('jsonld');
+const lodash_1 = require("lodash");
 const Config = require("./config");
 const helpers_1 = require("./helpers");
 const cayley = Cayley(Config.CAYLEY_ADDRESS);
+function quadIdentity({ label, subject, predicate, object }) {
+    return `${label}: ${subject} ${predicate} ${object}`;
+}
 function init({ name }) {
     return __awaiter(this, void 0, void 0, function* () {
         const receive = (send) => (operation) => __awaiter(this, void 0, void 0, function* () {
             if (!memux_1.isOperation(operation))
                 throw new Error();
             const { action, data } = operation;
+            const existingQuads = yield helpers_1.getQuads(data['@id']);
             const quads = yield feedbackfruits_knowledge_engine_1.Helpers.docToQuads(data);
-            console.log('Processing quads:', action, data, quads);
-            if (quads.length === 0)
+            const diff = lodash_1.differenceBy(lodash_1.unionBy(quads, existingQuads, quadIdentity), existingQuads, quadIdentity);
+            console.log('Processing diff:', diff);
+            if (diff.length === 0)
                 return;
+            let docs;
             switch (action) {
                 case 'write':
-                    try {
-                        console.log(yield helpers_1.writeQuads(quads));
-                    }
-                    catch (e) {
-                        console.error(e);
-                        if (e.message.match(/quad exists/)) {
-                            console.log('Found existing quad in: ', quads);
-                            return;
-                        }
-                        throw e;
-                    }
+                    console.log(yield helpers_1.writeQuads(diff));
+                    docs = feedbackfruits_knowledge_engine_1.Helpers.quadsToDocs(lodash_1.unionBy(existingQuads, diff, quadIdentity));
                     break;
                 case 'delete':
-                    try {
-                        console.log(yield helpers_1.deleteQuads(quads));
-                    }
-                    catch (e) {
-                        console.error(e);
-                        if (e.message.match(/quad does not exists/)) {
-                            console.log('Found existing quad in: ', quads);
-                            return;
-                        }
-                        throw e;
-                    }
+                    console.log(yield helpers_1.deleteQuads(diff));
+                    docs = feedbackfruits_knowledge_engine_1.Helpers.quadsToDocs(lodash_1.differenceBy(existingQuads, diff, quadIdentity));
                     break;
             }
-            console.log('Quads processed. Sending updated doc...');
-            yield Promise.all(feedbackfruits_knowledge_engine_1.Helpers.quadsToDocs(yield helpers_1.getDoc(data['@id'])).map(data => send({ action, key: data['@id'], data })));
+            console.log('Quads processed. Sending updated doc(s)...');
+            yield Promise.all(docs.map(data => send({ action, key: data['@id'], data })));
             return;
         });
         return feedbackfruits_knowledge_engine_1.Annotator({

--- a/package-lock.json
+++ b/package-lock.json
@@ -279,7 +279,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
       "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
       "requires": {
-        "lodash": "4.16.4"
+        "lodash": "4.17.4"
       }
     },
     "async-each": {
@@ -1204,7 +1204,7 @@
       "resolved": "https://registry.npmjs.org/bin-protocol/-/bin-protocol-3.0.4.tgz",
       "integrity": "sha1-RlqdNQb+sOEmtStbIWDZNuFbJ/Q=",
       "requires": {
-        "lodash": "4.16.4",
+        "lodash": "4.17.4",
         "long": "3.2.0",
         "protocol-buffers-schema": "3.3.1"
       }
@@ -2895,9 +2895,9 @@
       }
     },
     "lodash": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-      "integrity": "sha1-Ac4wa5utExnypVKGdPiCl663ASc="
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -3413,7 +3413,7 @@
       "resolved": "https://registry.npmjs.org/nice-simple-logger/-/nice-simple-logger-1.0.1.tgz",
       "integrity": "sha1-D55khSe+e+PkmrdvqMjAmK+VG/Y=",
       "requires": {
-        "lodash": "4.16.4"
+        "lodash": "4.17.4"
       }
     },
     "nise": {
@@ -3454,6 +3454,11 @@
         "wrr-pool": "1.1.3"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.16.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+          "integrity": "sha1-Ac4wa5utExnypVKGdPiCl663ASc="
+        },
         "typescript": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.1.tgz",
@@ -6951,7 +6956,7 @@
       "resolved": "https://registry.npmjs.org/wrr-pool/-/wrr-pool-1.1.3.tgz",
       "integrity": "sha1-/a0i8uofMDY//l14HPeUl6d/8H4=",
       "requires": {
-        "lodash": "4.16.4"
+        "lodash": "4.17.4"
       }
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@types/lodash": "^4.14.74",
     "@types/n3": "0.0.2",
     "@types/node": "^8.0.24",
     "@types/p-queue": "^1.1.0",
@@ -49,6 +50,7 @@
     "feedbackfruits-knowledge-engine": "github:feedbackfruits/feedbackfruits-knowledge-engine#feature/better-base",
     "isuri": "^2.0.3",
     "jsonld": "^0.4.12",
+    "lodash": "^4.17.4",
     "memux": "github:knowledge-express/memux#semver:~0.4.0",
     "n3": "^0.11.1",
     "node-fetch": "^1.7.2",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,7 +5,7 @@ import fetch from 'node-fetch';
 
 import { CAYLEY_ADDRESS } from './config';
 
-export async function getDoc(subject): Promise<Quad[]> {
+export async function getQuads(subject): Promise<Quad[]> {
   console.log('Getting doc:', subject);
   const query = `
   var subject = ${JSON.stringify(Helpers.encodeIRI(subject))};
@@ -38,7 +38,7 @@ export async function getDoc(subject): Promise<Quad[]> {
   })
   .then(({ result }) => {
         console.log('Returning resulting quads:', result);
-        return result as Quad[];
+        return (result || []) as Quad[];
       })
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,47 @@ import init from '../lib';
 import memux from 'memux';
 import { NAME, KAFKA_ADDRESS, INPUT_TOPIC, OUTPUT_TOPIC } from '../lib/config';
 
+const videoDoc = {
+  "@id": "https://www.youtube.com/watch?v=pi3WWQ0q6Lc",
+  "http://schema.org/sourceOrganization": [
+    "KhanAcademy"
+  ],
+  "http://schema.org/license": [
+    "<http://creativecommons.org/licenses/by-nc-sa/3.0>"
+  ],
+  "http://schema.org/name": [
+    "Multiplying positive and negative fractions"
+  ],
+  "http://schema.org/description": [
+    "See examples of multiplying and dividing fractions with negative numbers."
+  ],
+  "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": [
+    "<http://schema.org/VideoObject>",
+    "<https://knowledge.express/Resource>"
+  ],
+  "https://knowledge.express/topic": [
+    "<https://www.khanacademy.org/video/multiplying-negative-and-positive-fractions>"
+  ],
+  "http://schema.org/image": [
+    "<https://cdn.kastatic.org/googleusercontent/vkR4iP2PXl0SGkwmmpX-7N9mKNP7RWX8ilHMuROW745BJBvmp_eElCItbyPY-tweaVYgddFoNaaHpXSanPm92ZUS>"
+  ]
+};
+
+const concepts = [
+  "<http://dbpedia.org/resource/Divisor>",
+  "<http://dbpedia.org/resource/Elementary_arithmetic>",
+  "<http://dbpedia.org/resource/Integer>",
+  "<http://dbpedia.org/resource/Greatest_common_divisor>",
+  "<http://dbpedia.org/resource/Integer>",
+  "<http://dbpedia.org/resource/Divisor>",
+  "<http://dbpedia.org/resource/Greatest_common_divisor>",
+  "<http://dbpedia.org/resource/Elementary_arithmetic>",
+  "<http://dbpedia.org/resource/Integer>",
+  "<http://dbpedia.org/resource/Greatest_common_divisor>",
+  "<http://dbpedia.org/resource/Divisor>",
+  "<http://dbpedia.org/resource/Elementary_arithmetic>"
+];
+
 test('it exists', t => {
   t.not(init, undefined);
 });
@@ -40,11 +81,11 @@ test('it works and deduplicates', async (t) => {
       name: NAME,
     });
 
-    const doc = {
-      '@id': 'http://some.domain/testdoc',
-      'http://schema.org/name': [ 'bla' ],
-    };
-    const operation = { action: 'write', key: doc['@id'], data: doc}
+    // const doc = {
+    //   '@id': 'http://some.domain/testdoc',
+    //   'http://schema.org/name': [ 'bla' ],
+    // };
+    const operation = { action: 'write', key: videoDoc['@id'], data: videoDoc}
 
     const waitingPromise = new Promise((resolve) => {
       setTimeout(() => resolve(), 2000);


### PR DESCRIPTION
When writing multiple quads, none of them seem to get written when one or more already exists when Cayley doesn't allow duplicates. The following solution avoids the problem of deduplication altogether by taking a quad diff before applying the operation and as such always processing only a minimal and valid set of quads. As such, deduplication occurs naturally and the Cayley setting doesn't matter anymore. Therefore, a proper error is now thrown if duplicate quads occur, since it shouldn't happen.