### PR TITLE
Skip operation that break on data processing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,9 +25,17 @@ function init({ name }) {
             if (!memux_1.isOperation(operation))
                 throw new Error();
             const { action, data } = operation;
-            const existingQuads = yield Helpers.existingQuadsForDoc(data);
-            const quads = yield feedbackfruits_knowledge_engine_1.Doc.toQuads(data);
-            const diff = lodash_1.differenceBy(lodash_1.unionBy(quads, existingQuads, quadIdentity), existingQuads, quadIdentity);
+            let existingQuads, quads, diff;
+            try {
+                existingQuads = yield Helpers.existingQuadsForDoc(data);
+                quads = yield feedbackfruits_knowledge_engine_1.Doc.toQuads(data);
+                diff = lodash_1.differenceBy(lodash_1.unionBy(quads, existingQuads, quadIdentity), existingQuads, quadIdentity);
+            }
+            catch (e) {
+                console.log('ERROR! Skipping doc.');
+                console.error(e);
+                return;
+            }
             console.log('Processing diff:', diff);
             if (diff.length === 0)
                 return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,9 +25,16 @@ async function init({ name }: BrokerConfig) {
     if (!isOperation(operation)) throw new Error();
     const { action, data } = operation;
 
-    const existingQuads = await Helpers.existingQuadsForDoc(data);
-    const quads = await Doc.toQuads(data);
-    const diff = differenceBy(unionBy(quads, existingQuads, quadIdentity), existingQuads, quadIdentity);
+    let existingQuads, quads, diff;
+    try {
+      existingQuads = await Helpers.existingQuadsForDoc(data);
+      quads = await Doc.toQuads(data);
+      diff = differenceBy(unionBy(quads, existingQuads, quadIdentity), existingQuads, quadIdentity);
+    } catch(e) {
+      console.log('ERROR! Skipping doc.');
+      console.error(e)
+      return;
+    }
 
     // console.log('Processing quads:', action, data, quads);
     console.log('Processing diff:', diff);


### PR DESCRIPTION
The graph-broker appears to loop by resetting to the position of an erroring document on the bus, even without being turned off and on. This should allow it to continue past the point it gets stuck. The intended behaviour for an error scenario should be figured out, because this is not obviously not working.